### PR TITLE
v1.0.0 Candidate - Better response handling and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 The Go client library for the Tuneup Technology App.
 
-The Go client library allows you to interact with the customers, tickets, inventory, and locations objects without needing to do the hard work of binding your calls and data to endpoints. Simply call an action such as `CreateCustomer` and pass some data and let the library do the rest.
+[![MIT Licence](https://badges.frapsoft.com/os/mit/mit.svg?v=103)](https://opensource.org/licenses/mit-license.php)
+
+This library allows you to interact with the customers, tickets, inventory, and locations objects without needing to do the hard work of binding your calls and data to endpoints. Simply call an action such as `CreateCustomer` and pass some data and let the library do the rest.
 
 ## Install
 
@@ -16,28 +18,31 @@ go get -u github.com/ncr4/tuneuptechnology-go
 package main
 
 import (
+	"os"
 	"github.com/ncr4/tuneuptechnology-go"
 )
 
 func main() {
-	tuneuptechnology.CreateCustomer(
-		// Pass in your email and API key
-		&tuneuptechnology.Client{
-			Auth: "",
-			APIKey: "",
-		},
+	// Setup your email and API key
+	api_email := os.Getenv("API_EMAIL")
+	api_key := os.Getenv("API_KEY")
 
-		// Create a customer passing in all required params
+	// Create a customer passing in all required params
+	customer := tuneuptechnology.CreateCustomer(
 		&tuneuptechnology.Customer{
-			Firstname: "Go",
-			Lastname: "Test",
-			Email: "go-test@test.com",
-			Phone: "8018981234",
+			Auth: api_email,
+			APIKey: api_key,
+			Firstname: "Jake",
+			Lastname: "Peralta",
+			Email: "jake@example.com",
+			Phone: "8015551234",
 			UserId: 1,
-			Notes: "Testing some notes here",
+			Notes: "Believes he is a good detective.",
 			LocationId: 1,
 		},
 	)
+
+	tuneuptechnology.PrettyPrint(customer)
 }
 ```
 
@@ -46,21 +51,17 @@ Other examples can be found in the `/examples` directory. Alter according to you
 ## Usage
 
 ```bash
-go run create_customer.go
+API_EMAIL=email@example.com API_KEY=123... go run create_customer.go
 ```
 
 ## Documentation
 
-Up-to-date documentation can be [found here](https://app.tuneuptechnology.com/docs/api).
+Up-to-date API documentation can be [found here](https://app.tuneuptechnology.com/docs/api).
 
 ## Releasing
 
+As a separate PR from the feature/bug PR:
+
 1. Update the Version constant in `version.go`
-1. Update CHANGELOG
-1. Create a git tag with proper Go version semantics (eg: v1.0.0)
-
-## TODO
-
-- User-Agent
-- Response (JSON pretty printed)
-- Remove double maps and use structs as they were meant
+1. Update `CHANGELOG`
+1. Create a GitHub tag with proper Go version semantics (eg: v1.0.0)

--- a/client.go
+++ b/client.go
@@ -1,7 +1,6 @@
 package tuneuptechnology
 
 import (
-    "fmt"
     "io/ioutil"
     "net/http"
 	"log"
@@ -11,25 +10,28 @@ import (
 
 // Setup the HTTP client and response functionality
 const APIBaseUrl = "https://app.tuneuptechnology.com/api/"
-// const UserAgent = "Tuneup_Technology_App/GoClient/" + Version // TODO: Implement this
 
-type Client struct {
-	Auth 		string `json:"auth"`
-	APIKey		string `json:"api_key"`
-}
-
-func Response(values map[string]interface{}, endpoint string) {
-	jsonData, _ := json.Marshal(values)
-
-	response, err := http.Post(endpoint, "application/json", bytes.NewBuffer(jsonData))
+// Request a response from the API with supplied data
+func Response(data interface{}, endpoint string) map[string]interface{} {
+    // Make a request to the API
+    jsonData, _ := json.Marshal(data)
+	request, err := http.Post(endpoint, "application/json", bytes.NewBuffer(jsonData))
     if err != nil {
         log.Fatal(err)
     }
 
-    responseData, err := ioutil.ReadAll(response.Body)
+    // Read the response data from the API
+    responseData, err := ioutil.ReadAll(request.Body)
     if err != nil {
         log.Fatal(err)
-	}
-	
-    fmt.Println(string(responseData))
+    }
+
+    // Convert the response to a map
+    var response map[string]interface{}
+    err = json.Unmarshal(responseData, &response)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    return response
 }

--- a/customer.go
+++ b/customer.go
@@ -4,8 +4,9 @@ import (
     "strconv"
 )
 
-// Customer Struct
-type Customer struct {    
+type Customer struct {
+    Auth        string  `json:"auth"`
+    APIKey      string  `json:"api_key"`
     Id          int     `json:"id"`
     Firstname   string  `json:"firstname"`
     Lastname    string  `json:"lastname"`
@@ -17,75 +18,31 @@ type Customer struct {
 }
 
 // Create a customer
-func CreateCustomer(client *Client, data *Customer) {
-	values := map[string]interface{}{
-		"auth":         client.Auth,
-        "api_key":      client.APIKey,
-        "firstname":    data.Firstname,
-        "lastname":     data.Lastname,
-        "email":        data.Email,
-        "phone":        data.Phone,
-        "user_id":      data.UserId,
-        "notes":        data.Notes,
-        "location_id":  data.LocationId,
-	}
-
+func CreateCustomer(data *Customer) map[string]interface{} {
     endpoint := APIBaseUrl + "customers/create"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Retrieve a list of customers
-func RetrieveCustomers(client *Client) {
-    values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-    }
-
+func AllCustomers(data *Customer) map[string]interface{} {
     endpoint := APIBaseUrl + "customers"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Retrieve a single customer
-func RetrieveCustomer(client *Client, data *Customer) {
-    values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-    }
-
+func RetrieveCustomer(data *Customer) map[string]interface{} {
     endpoint := APIBaseUrl + "customers/" + strconv.Itoa(data.Id)
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Update a customer
-func UpdateCustomer(client *Client, data *Customer) {
-	values := map[string]interface{}{
-		"auth":         client.Auth,
-        "api_key":      client.APIKey,
-        "firstname":    data.Firstname,
-        "lastname":     data.Lastname,
-        "email":        data.Email,
-        "phone":        data.Phone,
-        "user_id":      data.UserId,
-        "notes":        data.Notes,
-        "location_id":  data.LocationId,
-	}
-
+func UpdateCustomer(data *Customer) map[string]interface{} {
     endpoint := APIBaseUrl + "customers/" + strconv.Itoa(data.Id) + "/update"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Delete a customer
-func DeleteCustomer(client *Client, data *Customer) {
-    values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-    }
-
+func DeleteCustomer(data *Customer) map[string]interface{} {
     endpoint := APIBaseUrl + "customers/" + strconv.Itoa(data.Id) + "/delete"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }

--- a/examples/create_customer.go
+++ b/examples/create_customer.go
@@ -1,26 +1,29 @@
 package main
 
 import (
+	"os"
 	"github.com/ncr4/tuneuptechnology-go"
 )
 
 func main() {
-	tuneuptechnology.CreateCustomer(
-		// Pass in your email and API key
-		&tuneuptechnology.Client{
-			Auth: "",
-			APIKey: "",
-		},
+	// Setup your email and API key
+	api_email := os.Getenv("API_EMAIL")
+	api_key := os.Getenv("API_KEY")
 
-		// Create a customer passing in all required params
+	// Create a customer passing in all required params
+	customer := tuneuptechnology.CreateCustomer(
 		&tuneuptechnology.Customer{
-			Firstname: "Go",
-			Lastname: "Test",
-			Email: "go-test@test.com",
-			Phone: "8018981234",
+			Auth: api_email,
+			APIKey: api_key,
+			Firstname: "Jake",
+			Lastname: "Peralta",
+			Email: "jake@example.com",
+			Phone: "8015551234",
 			UserId: 1,
-			Notes: "Testing some notes here",
+			Notes: "Believes he is a good detective.",
 			LocationId: 1,
 		},
 	)
+
+	tuneuptechnology.PrettyPrint(customer)
 }

--- a/examples/delete_customer.go
+++ b/examples/delete_customer.go
@@ -1,20 +1,23 @@
 package main
 
 import (
+	"os"
 	"github.com/ncr4/tuneuptechnology-go"
 )
 
 func main() {
-	tuneuptechnology.DeleteCustomer(		
-		// Pass in your email and API key
-		&tuneuptechnology.Client{
-			Auth: "",
-			APIKey: "",
-		},
+	// Setup your email and API key
+	api_email := os.Getenv("API_EMAIL")
+	api_key := os.Getenv("API_KEY")
 
-		// deletes customer with ID #23
+	// Delete a customer
+	customer := tuneuptechnology.DeleteCustomer(
 		&tuneuptechnology.Customer{
-			Id: 23,
+			Auth: api_email,
+			APIKey: api_key,
+			Id: 1, // the ID of the customer you are deleting
 		},
 	)
+
+	tuneuptechnology.PrettyPrint(customer)
 }

--- a/examples/retrieve_customer.go
+++ b/examples/retrieve_customer.go
@@ -1,20 +1,26 @@
 package main
 
 import (
+	"os"
 	"github.com/ncr4/tuneuptechnology-go"
 )
 
 func main() {
-	tuneuptechnology.RetrieveCustomer(
-		// Pass in your email and API key
-		&tuneuptechnology.Client{
-			Auth: "",
-			APIKey: "",
-		},
+	// Setup your email and API key
+	api_email := os.Getenv("API_EMAIL")
+	api_key := os.Getenv("API_KEY")
 
-		// retrieves customer with ID #23
+	// Retrieve a single customer
+	customer := tuneuptechnology.RetrieveCustomer(
 		&tuneuptechnology.Customer{
-			Id: 23,
+			Auth: api_email,
+			APIKey: api_key,
+			Id: 1, // the ID of the customer you are retrieving
 		},
 	)
+
+	tuneuptechnology.PrettyPrint(customer)
+
+	// Alternatively, print individual items from the response:
+	// fmt.Println(customer["data"].(map[string]interface{})["firstname"], customer["data"].(map[string]interface{})["lastname"])
 }

--- a/examples/retrieve_customers.go
+++ b/examples/retrieve_customers.go
@@ -1,17 +1,22 @@
 package main
 
 import (
+	"os"
 	"github.com/ncr4/tuneuptechnology-go"
 )
 
 func main() {
-	tuneuptechnology.RetrieveCustomers(
-		// Pass in your email and API key
-		&tuneuptechnology.Client{
-			Auth: "",
-			APIKey: "",
-		},
+	// Setup your email and API key
+	api_email := os.Getenv("API_EMAIL")
+	api_key := os.Getenv("API_KEY")
 
-		// Retrieves all customers
+	// Retrieve all customers
+	customers := tuneuptechnology.AllCustomers(
+		&tuneuptechnology.Customer{
+			Auth: api_email,
+			APIKey: api_key,
+		},
 	)
+
+	tuneuptechnology.PrettyPrint(customers)
 }

--- a/examples/update_customer.go
+++ b/examples/update_customer.go
@@ -1,27 +1,30 @@
 package main
 
 import (
+	"os"
 	"github.com/ncr4/tuneuptechnology-go"
 )
 
 func main() {
-	tuneuptechnology.UpdateCustomer(
-		// Pass in your email and API key
-		&tuneuptechnology.Client{
-			Auth: "",
-			APIKey: "",
-		},
-		
-		// Update a customer passing in all the desired params to be updated
+	// Setup your email and API key
+	api_email := os.Getenv("API_EMAIL")
+	api_key := os.Getenv("API_KEY")
+
+	// Update a customer passing in all the params you want to update
+	customer := tuneuptechnology.UpdateCustomer(
 		&tuneuptechnology.Customer{
-			Id: 1, // the ID of the customer you want to update
-			Firstname: "Go",
-			Lastname: "Test",
-			Email: "go-test@test.com",
-			Phone: "8018981234",
+			Auth: api_email,
+			APIKey: api_key,
+			Id: 1, // the ID of the customer you are updating
+			Firstname: "Jake",
+			Lastname: "Peralta",
+			Email: "jake@example.com",
+			Phone: "8015551234",
 			UserId: 1,
-			Notes: "Testing some notes here",
+			Notes: "Believes he is a good detective.",
 			LocationId: 1,
 		},
 	)
+
+	tuneuptechnology.PrettyPrint(customer)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module local.com/ncr4/tuneuptechnology-go
+module github.com/ncr4/tuneuptechnology-go
 
 go 1.14

--- a/inventory.go
+++ b/inventory.go
@@ -4,8 +4,9 @@ import (
     "strconv"
 )
 
-// Inventory Struct
-type Inventory struct {    
+type Inventory struct {
+    Auth            string  `json:"auth"`
+    APIKey          string  `json:"api_key"`
     Id              int     `json:"id"`
     Name            string  `json:"name"`
     Quantity        int     `json:"quantity"`
@@ -16,73 +17,31 @@ type Inventory struct {
 }
 
 // Create an inventory item
-func CreateInventory(client *Client, data *Inventory) {
-	values := map[string]interface{}{
-		"auth":                 client.Auth,
-        "api_key":              client.APIKey,
-        "name":                 data.Name,
-        "quantity":             data.Quantity,
-        "inventory_type_id":    data.InventoryTypeId,
-        "sku":                  data.SKU,
-        "part_price":           data.PartPrice,
-        "location_id":          data.LocationId,
-    }
-    
+func CreateInventory(data *Inventory) map[string]interface{} {
     endpoint := APIBaseUrl + "inventory/create"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Retrieve a list of inventory items
-func RetrieveInventorys(client *Client) {
-	values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-	}
-
+func AllInventory(data *Inventory) map[string]interface{} {
     endpoint := APIBaseUrl + "inventory"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Retrieve a single inventory item
-func RetrieveInventory(client *Client, data *Inventory) {
-    values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-    }
-
+func RetrieveInventory(data *Inventory) map[string]interface{} {
     endpoint := APIBaseUrl + "inventory/" + strconv.Itoa(data.Id)
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Update an inventory item
-func UpdateInventory(client *Client, data *Inventory) {
-	values := map[string]interface{}{
-		"auth":                 client.Auth,
-        "api_key":              client.APIKey,
-        "name":                 data.Name,
-        "quantity":             data.Quantity,
-        "inventory_type_id":    data.InventoryTypeId,
-        "sku":                  data.SKU,
-        "part_price":           data.PartPrice,
-        "location_id":          data.LocationId,
-	}
-
+func UpdateInventory(data *Inventory) map[string]interface{} {
     endpoint := APIBaseUrl + "inventory/" + strconv.Itoa(data.Id) + "/update"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Delete an inventory item
-func DeleteInventory(client *Client, data *Inventory) {
-    values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-    }
-
+func DeleteInventory(data *Inventory) map[string]interface{} {
     endpoint := APIBaseUrl + "inventorys/" + strconv.Itoa(data.Id) + "/delete"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }

--- a/location.go
+++ b/location.go
@@ -4,82 +4,43 @@ import (
     "strconv"
 )
 
-// Location Struct
-type Location struct {    
-    Id     int     `json:"id"`
-    Name   string  `json:"name"`
-    Street string  `json:"street"`
-    City   string  `json:"city"`
-    State  string  `json:"state"`
-    Zip    int     `json:"zip"`
+type Location struct {
+    Auth    string  `json:"auth"`
+    APIKey  string  `json:"api_key"`
+    Id      int     `json:"id"`
+    Name    string  `json:"name"`
+    Street  string  `json:"street"`
+    City    string  `json:"city"`
+    State   string  `json:"state"`
+    Zip     int     `json:"zip"`
 }
 
 // Create a location
-func CreateLocation(client *Client, data *Location) {
-	values := map[string]interface{}{
-		"auth":     client.Auth,
-        "api_key":  client.APIKey,
-        "name":     data.Name,
-        "street":   data.Street,
-        "city":     data.City,
-        "state":    data.State,
-        "zip":      data.Zip,
-	}
-
+func CreateLocation(data *Location) map[string]interface{} {
     endpoint := APIBaseUrl + "locations/create"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Retrieve a list of locations
-func RetrieveLocations(client *Client) {
-	values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-	}
-
+func AllLocations(data *Location) map[string]interface{} {
     endpoint := APIBaseUrl + "locations"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Retrieve a single location
-func RetrieveLocation(client *Client, data *Location) {
-    values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-    }
-
+func RetrieveLocation(data *Location) map[string]interface{} {
     endpoint := APIBaseUrl + "locations/" + strconv.Itoa(data.Id)
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Update a location
-func UpdateLocation(client *Client, data *Location) {
-	values := map[string]interface{}{
-		"auth":     client.Auth,
-        "api_key":  client.APIKey,
-        "name":     data.Name,
-        "street":   data.Street,
-        "city":     data.City,
-        "state":    data.State,
-        "zip":      data.Zip,
-    }
-    
+func UpdateLocation(data *Location) map[string]interface{} {
     endpoint := APIBaseUrl + "locations/" + strconv.Itoa(data.Id) + "/update"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Delete a location
-func DeleteLocation(client *Client, data *Location) {
-    values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-    }
-
+func DeleteLocation(data *Location) map[string]interface{} {
     endpoint := APIBaseUrl + "locations/" + strconv.Itoa(data.Id) + "/delete"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }

--- a/ticket.go
+++ b/ticket.go
@@ -4,8 +4,9 @@ import (
     "strconv"
 )
 
-// Ticket Struct
-type Ticket struct {    
+type Ticket struct {
+    Auth            string  `json:"auth"`
+    APIKey          string  `json:"api_key"`
     Id              int     `json:"id"`
     CustomerId      int     `json:"customer_id"`
     TicketTypeId    int     `json:"ticket_type_id"`
@@ -20,81 +21,31 @@ type Ticket struct {
 }
 
 // Create a ticket
-func CreateTicket(client *Client, data *Ticket) {
-	values := map[string]interface{}{
-		"auth":             client.Auth,
-        "api_key":          client.APIKey,
-        "customer_id":      data.CustomerId,
-        "ticket_type_id":   data.TicketTypeId,
-        "serial":           data.Serial,
-        "user_id":          data.UserId,
-        "notes":            data.Notes,
-        "title":            data.Title,
-        "status":           data.Status,
-        "device":           data.Device,
-        "imei":             data.IMEI,
-        "location_id":      data.LocationId,
-    }
-
+func CreateTicket(data *Ticket) map[string]interface{} {
     endpoint := APIBaseUrl + "tickets/create"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Retrieve a list of tickets
-func RetrieveTickets(client *Client) {
-	values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-    }
-    
+func AllTickets(data *Ticket) map[string]interface{} {
     endpoint := APIBaseUrl + "tickets"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Retrieve a single ticket
-func RetrieveTicket(client *Client, data *Ticket) {
-    values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-    }
-
+func RetrieveTicket(data *Ticket) map[string]interface{} {
     endpoint := APIBaseUrl + "tickets/" + strconv.Itoa(data.Id)
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Update a ticket
-func UpdateTicket(client *Client, data *Ticket) {
-	values := map[string]interface{}{
-		"auth":             client.Auth,
-        "api_key":          client.APIKey,
-        "customer_id":      data.CustomerId,
-        "ticket_type_id":   data.TicketTypeId,
-        "serial":           data.Serial,
-        "user_id":          data.UserId,
-        "notes":            data.Notes,
-        "title":            data.Title,
-        "status":           data.Status,
-        "device":           data.Device,
-        "imei":             data.IMEI,
-        "location_id":      data.LocationId,
-    }
-    
+func UpdateTicket(data *Ticket) map[string]interface{} {
     endpoint := APIBaseUrl + "tickets/" + strconv.Itoa(data.Id) + "/update"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }
 
 // Delete a ticket
-func DeleteTicket(client *Client, data *Ticket) {
-    values := map[string]interface{}{
-		"auth": client.Auth,
-        "api_key": client.APIKey,
-    }
-
+func DeleteTicket(data *Ticket) map[string]interface{} {
     endpoint := APIBaseUrl + "tickets/" + strconv.Itoa(data.Id) + "/delete"
-
-    Response(values, endpoint)
+    return Response(data, endpoint)
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,16 @@
+package tuneuptechnology
+
+import (
+    "fmt"
+	"os"
+	"encoding/json"
+)
+
+// Helper util to pretty print JSON
+func PrettyPrint(data map[string]interface{}) {
+    prettyJSON, err := json.MarshalIndent(data, "", "    ")
+    if err != nil {
+    	fmt.Fprintln(os.Stderr, "error creating JSON:", err)
+    }
+    fmt.Printf("%s\n", string(prettyJSON))
+}


### PR DESCRIPTION
This is a huge rewrite of the library making it v1.0.0 eligible as it's first official release.

- Uses maps properly and returns the data instead of assuming the user wants it printed via the library
- Uses the built-in structures properly as the data can be inherited from the structure instead of remapped again
- Better examples to match with these rewrites, more options for the end users now too

Once this is approved and merged, I will create a separate PR to bump the version to `v1.0.0` and request that one be merged too separate from this one.